### PR TITLE
Add support for a local user identifier

### DIFF
--- a/Sources/TeamUpKitTests/TeamupKitAuthenticationTests.swift
+++ b/Sources/TeamUpKitTests/TeamupKitAuthenticationTests.swift
@@ -17,7 +17,7 @@ class TeamupKitAuthenticationTests: TeamupKitTests {
         teamup.auth.logIn(email: "Test User",
                           password: "Test Password",
                           success: { (user) in
-              XCTAssertTrue(user.expires.count > 0)
+              XCTAssertTrue(user.expires?.count ?? 0 > 0)
         }) { (error, details) in
             XCTFail("Log In method fails")
         }

--- a/Sources/TeamupKit/Controllers/Account/Memberships/MembershipsApiController.swift
+++ b/Sources/TeamupKit/Controllers/Account/Memberships/MembershipsApiController.swift
@@ -19,7 +19,7 @@ class MembershipsApiController: AuthenticatedApiController, MembershipsControlle
         var parameters: Alamofire.Parameters = [
             "business" : config.business.businessId,
         ]
-        if let customerId = auth?.currentUser?.customer.id {
+        if let customerId = auth?.currentUser?.customer?.id {
             parameters["customer"] = customerId
         }
         

--- a/Sources/TeamupKit/Controllers/Authentication/AuthenticationApiController.swift
+++ b/Sources/TeamupKit/Controllers/Authentication/AuthenticationApiController.swift
@@ -98,7 +98,7 @@ private extension AuthenticationApiController {
         
         // ignore log in if already logged in
         if force == false && currentUser != nil && currentUserAuthData != nil {
-            guard !(currentUser?.customer.emails.contains(where: { $0 == email }) ?? false) else {
+            guard !(currentUser?.customer?.emails.contains(where: { $0 == email }) ?? false) else {
                 success?(currentUser!)
                 return
             }
@@ -211,7 +211,9 @@ extension AuthenticationApiController: RequestExecutorAuthResponder {
                          response: Response,
                          success: @escaping (Request, Response, Data?) -> Void,
                          failure: @escaping (Request, Response?, Error) -> Void) {
-        guard let currentUser = currentUser , let authData = currentUserAuthData else {
+        guard let currentUser = currentUser,
+            let authData = currentUserAuthData,
+            let email = currentUser.customer?.emails.first else {
             signOut()
             return
         }
@@ -220,7 +222,7 @@ extension AuthenticationApiController: RequestExecutorAuthResponder {
         print("Attempting to reauth")
         
         // attempt to reauthenticate current user and then execute request
-        performLogIn(with: currentUser.customer.emails.first!,
+        performLogIn(with: email,
                      password: authData.password,
                      success:
             { (user) in

--- a/Sources/TeamupKit/Controllers/Authentication/AuthenticationApiController.swift
+++ b/Sources/TeamupKit/Controllers/Authentication/AuthenticationApiController.swift
@@ -204,8 +204,8 @@ private extension AuthenticationApiController {
 extension AuthenticationApiController: RequestBuilderAuthProvider {
     
     func requestBuilder(requestUserTokenAuthHeaders requestBuilder: RequestBuilder) -> [String : String]? {
-        guard let currentUser = self.currentUser else { return nil }
-        return ["Authorization"  : "Token \(currentUser.token)"]
+        guard let token = self.currentUser?.token else { return nil }
+        return ["Authorization"  : "Token \(token)"]
     }
     
     func requestBuilder(requestApiTokenAuthHeaders requestBuilder: RequestBuilder) -> [String : String]? {

--- a/Sources/TeamupKit/Controllers/Authentication/AuthenticationApiController.swift
+++ b/Sources/TeamupKit/Controllers/Authentication/AuthenticationApiController.swift
@@ -34,7 +34,7 @@ class AuthenticationApiController: ApiController, AuthenticationController {
     private var loginRequest: Request?
     
     var isAuthenticated: Bool {
-        return currentUser != nil
+        return currentUser?.success == true
     }
     
     // MARK: Init
@@ -80,8 +80,9 @@ class AuthenticationApiController: ApiController, AuthenticationController {
     func signOut() {
         guard self.currentUser != nil else { return }
         
-        self.currentUser = nil
         clearKeychain()
+        self.currentUser = User.local
+        updateKeychain(for: currentUser, authData: nil)
         
         // TODO - Notify other controllers
     }
@@ -120,7 +121,8 @@ private extension AuthenticationApiController {
                 return
             }
             do {
-                let user = try self.decoder.decode(User.self, from: data)
+                var user = try self.decoder.decode(User.self, from: data)
+                user.identifier = self.currentUser?.identifier
                 let authData = UserAuthData(password: password)
                 
                 self.updateKeychain(for: user, authData: authData)
@@ -148,7 +150,7 @@ private extension AuthenticationApiController {
     /// - Parameter authData: The new user's auth data.
     private func updateKeychain(for user: User?,
                                 authData: UserAuthData?) {
-        guard let user = user, let authData = authData else {
+        guard let user = user else {
             clearKeychain()
             return
         }
@@ -156,9 +158,12 @@ private extension AuthenticationApiController {
         let encoder = JSONEncoder()
         do {
             let userData = try encoder.encode(user)
-            let authData = try encoder.encode(authData)
             keychain.set(userData, forKey: KeychainKeys.user)
-            keychain.set(authData, forKey: KeychainKeys.userAuthData)
+
+            if let authData = authData {
+                let authData = try encoder.encode(authData)
+                keychain.set(authData, forKey: KeychainKeys.userAuthData)
+            }
         } catch {}
     }
     
@@ -171,7 +176,11 @@ private extension AuthenticationApiController {
     ///
     /// - Returns: The currently authenticated user.
     private func loadAuthenticatedUserIfAvailable() -> User? {
-        guard let data = keychain.getData(KeychainKeys.user) else { return nil }
+        guard let data = keychain.getData(KeychainKeys.user) else {
+            let localUser = User.local
+            updateKeychain(for: localUser, authData: nil)
+            return localUser
+        }
         do {
             return try decoder.decode(User.self, from: data)
         } catch {

--- a/Sources/TeamupKit/Controllers/Sessions/Registrations/RegistrationsApiController.swift
+++ b/Sources/TeamupKit/Controllers/Sessions/Registrations/RegistrationsApiController.swift
@@ -21,7 +21,7 @@ extension RegistrationsApiController {
                      failure: Controller.MethodFailure?) {
         
         var parameters: Alamofire.Parameters = [:]
-        if let customerId = auth?.currentUser?.customer.id {
+        if let customerId = auth?.currentUser?.customer?.id {
             parameters["customer"] = customerId
         }
         

--- a/Sources/TeamupKit/Controllers/Sessions/SessionsApiController.swift
+++ b/Sources/TeamupKit/Controllers/Sessions/SessionsApiController.swift
@@ -83,7 +83,7 @@ extension SessionsApiController {
         if let page = page {
             parameters["page"] = page
         }
-        if let customerId = auth?.currentUser?.customer.id {
+        if let customerId = auth?.currentUser?.customer?.id {
             parameters["customer"] = customerId
         }
         
@@ -119,7 +119,7 @@ extension SessionsApiController {
         var parameters: Alamofire.Parameters = [
             "include_registration_details" : includeRegistrationDetails
         ]
-        if let customerId = auth?.currentUser?.customer.id {
+        if let customerId = auth?.currentUser?.customer?.id {
             parameters["customer"] = customerId
         }
         

--- a/Sources/TeamupKit/Controllers/Sessions/Waitlists/WaitlistsApiController.swift
+++ b/Sources/TeamupKit/Controllers/Sessions/Waitlists/WaitlistsApiController.swift
@@ -16,7 +16,7 @@ class WaitlistsApiController: AuthenticatedApiController, WaitlistsController {
               failure: Controller.MethodFailure?) {
         
         var parameters: Alamofire.Parameters = [:]
-        if let customerId = auth?.currentUser?.customer.id {
+        if let customerId = auth?.currentUser?.customer?.id {
             parameters["customer"] = customerId
         }
         
@@ -72,7 +72,7 @@ class WaitlistsApiController: AuthenticatedApiController, WaitlistsController {
         var parameters: Alamofire.Parameters = [
             "action" : action
         ]
-        if let customerId = auth?.currentUser?.customer.id {
+        if let customerId = auth?.currentUser?.customer?.id {
             parameters["customer"] = customerId
         }
         

--- a/Sources/TeamupKit/Model/User.swift
+++ b/Sources/TeamupKit/Model/User.swift
@@ -12,12 +12,14 @@ import Foundation
 public struct User: Codable {
     
     /// The customer associated with the user.
-    public let customer: Customer
+    public let customer: Customer?
     
     /// The access token for the user.
-    internal let token: String
+    internal let token: String?
     /// The expiry date of the token.
-    internal let expires: String
+    internal let expires: String?
     /// Whether the user was successfully authenticated.
-    internal let success: Bool
+    internal let success: Bool?
+    
+    
 }

--- a/Sources/TeamupKit/Model/User.swift
+++ b/Sources/TeamupKit/Model/User.swift
@@ -33,6 +33,17 @@ public struct User: Codable {
         self.success = nil
     }
     
+    internal init(customer: Customer,
+                 token: String,
+                 expires: String,
+                 success: Bool) {
+        self.customer = customer
+        self.identifier = UUID().uuidString
+        self.token = token
+        self.expires = expires
+        self.success = success
+    }
+    
     static var local: User {
         return User(identifier: UUID().uuidString)
     }

--- a/Sources/TeamupKit/Model/User.swift
+++ b/Sources/TeamupKit/Model/User.swift
@@ -13,6 +13,8 @@ public struct User: Codable {
     
     /// The customer associated with the user.
     public let customer: Customer?
+    /// The local unique identifier for the user.
+    internal(set) var identifier: String!
     
     /// The access token for the user.
     internal let token: String?
@@ -21,5 +23,17 @@ public struct User: Codable {
     /// Whether the user was successfully authenticated.
     internal let success: Bool?
     
+    // MARK: Local User
     
+    private init(identifier: String) {
+        self.customer = nil
+        self.identifier = identifier
+        self.token = nil
+        self.expires = nil
+        self.success = nil
+    }
+    
+    static var local: User {
+        return User(identifier: UUID().uuidString)
+    }
 }


### PR DESCRIPTION
Add a local identifier to `User` which is persistent across the user's entire 'session', and is only reset on sign out. 